### PR TITLE
feat: Add Grid trait

### DIFF
--- a/src/coordinate_system.rs
+++ b/src/coordinate_system.rs
@@ -1,4 +1,7 @@
-use crate::direction::{Direction, GridDelta};
+use crate::{
+    direction::{Direction, DirectionTrait, GridDelta},
+    grid::GridPosition,
+};
 
 #[cfg(feature = "bevy")]
 use bevy::ecs::component::Component;
@@ -7,10 +10,13 @@ use bevy::{ecs::reflect::ReflectComponent, reflect::Reflect};
 
 /// Represents a coordinate system
 pub trait CoordinateSystem: Default + Clone + Sync + Send + 'static {
+    type Direction: DirectionTrait;
+    type GridDelta;
+    type GridPosition;
     /// Returns the [`Direction`] in this coordinate system
-    fn directions(&self) -> &'static [Direction];
+    fn directions(&self) -> &'static [Self::Direction];
     /// Returns the [`GridDelta`] for each direction in this coordinate system
-    fn deltas(&self) -> &'static [GridDelta];
+    fn deltas(&self) -> &'static [Self::GridDelta];
 }
 
 /// Right-handed 2d Cartesian coordinate system: 4 directions
@@ -19,6 +25,9 @@ pub trait CoordinateSystem: Default + Clone + Sync + Send + 'static {
 #[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct Cartesian2D;
 impl CoordinateSystem for Cartesian2D {
+    type Direction = Direction;
+    type GridDelta = GridDelta;
+    type GridPosition = GridPosition;
     fn directions(&self) -> &'static [Direction] {
         CARTESIAN_2D_DIRECTIONS
     }
@@ -34,6 +43,9 @@ impl CoordinateSystem for Cartesian2D {
 #[cfg_attr(feature = "reflect", derive(Reflect), reflect(Component))]
 pub struct Cartesian3D;
 impl CoordinateSystem for Cartesian3D {
+    type Direction = Direction;
+    type GridDelta = GridDelta;
+    type GridPosition = GridPosition;
     fn directions(&self) -> &'static [Direction] {
         CARTESIAN_3D_DIRECTIONS
     }

--- a/src/coordinate_system.rs
+++ b/src/coordinate_system.rs
@@ -7,12 +7,20 @@ use bevy::{ecs::reflect::ReflectComponent, reflect::Reflect};
 
 /// Represents a coordinate system
 pub trait CoordinateSystem: Default + Clone + Sync + Send + 'static {
+    /// [DirectionTrait] type used in this system
     type Direction: DirectionTrait;
-    type GridDelta;
+
     /// Returns the [`Direction`] in this coordinate system
     fn directions(&self) -> &'static [Self::Direction];
+
+    /// Returns the total count of directions
+    fn directions_count(&self) -> usize;
+}
+
+/// Specific case for a cartesian coordinate system
+pub trait CartesianCoordinates: CoordinateSystem<Direction = Direction> {
     /// Returns the [`GridDelta`] for each direction in this coordinate system
-    fn deltas(&self) -> &'static [Self::GridDelta];
+    fn deltas(&self) -> &'static [GridDelta];
 }
 
 /// Right-handed 2d Cartesian coordinate system: 4 directions
@@ -22,11 +30,19 @@ pub trait CoordinateSystem: Default + Clone + Sync + Send + 'static {
 pub struct Cartesian2D;
 impl CoordinateSystem for Cartesian2D {
     type Direction = Direction;
-    type GridDelta = GridDelta;
+
+    #[inline]
     fn directions(&self) -> &'static [Direction] {
         CARTESIAN_2D_DIRECTIONS
     }
 
+    #[inline]
+    fn directions_count(&self) -> usize {
+        CARTESIAN_2D_DIRECTIONS.len()
+    }
+}
+impl CartesianCoordinates for Cartesian2D {
+    #[inline]
     fn deltas(&self) -> &'static [GridDelta] {
         CARTESIAN_2D_DELTAS
     }
@@ -39,11 +55,19 @@ impl CoordinateSystem for Cartesian2D {
 pub struct Cartesian3D;
 impl CoordinateSystem for Cartesian3D {
     type Direction = Direction;
-    type GridDelta = GridDelta;
+
+    #[inline]
     fn directions(&self) -> &'static [Direction] {
         CARTESIAN_3D_DIRECTIONS
     }
 
+    #[inline]
+    fn directions_count(&self) -> usize {
+        CARTESIAN_3D_DIRECTIONS.len()
+    }
+}
+impl CartesianCoordinates for Cartesian3D {
+    #[inline]
     fn deltas(&self) -> &'static [GridDelta] {
         CARTESIAN_3D_DELTAS
     }

--- a/src/coordinate_system.rs
+++ b/src/coordinate_system.rs
@@ -1,7 +1,4 @@
-use crate::{
-    direction::{Direction, DirectionTrait, GridDelta},
-    grid::GridPosition,
-};
+use crate::direction::{Direction, DirectionTrait, GridDelta};
 
 #[cfg(feature = "bevy")]
 use bevy::ecs::component::Component;

--- a/src/coordinate_system.rs
+++ b/src/coordinate_system.rs
@@ -12,7 +12,6 @@ use bevy::{ecs::reflect::ReflectComponent, reflect::Reflect};
 pub trait CoordinateSystem: Default + Clone + Sync + Send + 'static {
     type Direction: DirectionTrait;
     type GridDelta;
-    type GridPosition;
     /// Returns the [`Direction`] in this coordinate system
     fn directions(&self) -> &'static [Self::Direction];
     /// Returns the [`GridDelta`] for each direction in this coordinate system
@@ -27,7 +26,6 @@ pub struct Cartesian2D;
 impl CoordinateSystem for Cartesian2D {
     type Direction = Direction;
     type GridDelta = GridDelta;
-    type GridPosition = GridPosition;
     fn directions(&self) -> &'static [Direction] {
         CARTESIAN_2D_DIRECTIONS
     }
@@ -45,7 +43,6 @@ pub struct Cartesian3D;
 impl CoordinateSystem for Cartesian3D {
     type Direction = Direction;
     type GridDelta = GridDelta;
-    type GridPosition = GridPosition;
     fn directions(&self) -> &'static [Direction] {
         CARTESIAN_3D_DIRECTIONS
     }

--- a/src/direction.rs
+++ b/src/direction.rs
@@ -5,8 +5,16 @@ use bevy::ecs::component::Component;
 #[cfg(feature = "reflect")]
 use bevy::{ecs::reflect::ReflectComponent, reflect::Reflect};
 
-pub trait DirectionTrait: Into<usize> + Copy {
+// TODO Might reduce this to a u8
+/// Index of a direction
+pub type DirectionIndex = usize;
+
+// TODO, more generic
+/// Represents a direction in a grid layout
+pub trait DirectionTrait: Into<DirectionIndex> + Copy {
+    /// Returns the opposite [`Direction`]
     fn opposite(&self) -> Self;
+    /// Right-handed.
     fn rotation_basis(&self) -> &'static [Self];
 }
 

--- a/src/direction.rs
+++ b/src/direction.rs
@@ -5,6 +5,11 @@ use bevy::ecs::component::Component;
 #[cfg(feature = "reflect")]
 use bevy::{ecs::reflect::ReflectComponent, reflect::Reflect};
 
+pub trait DirectionTrait: Into<usize> + Copy {
+    fn opposite(&self) -> Self;
+    fn rotation_basis(&self) -> &'static [Self];
+}
+
 /// Represents an oriented axis of a coordinate system
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "bevy", derive(Component))]
@@ -24,9 +29,9 @@ pub enum Direction {
     /// Z- axis
     ZBackward = 5,
 }
-impl Direction {
+impl DirectionTrait for Direction {
     /// Returns the opposite [`Direction`]
-    pub fn opposite(&self) -> Direction {
+    fn opposite(&self) -> Direction {
         match self {
             Direction::XForward => Direction::XBackward,
             Direction::XBackward => Direction::XForward,
@@ -38,7 +43,7 @@ impl Direction {
     }
 
     /// Right-handed.
-    pub fn rotation_basis(&self) -> &'static [Direction] {
+    fn rotation_basis(&self) -> &'static [Direction] {
         match self {
             Direction::XForward => X_POS_AXIS,
             Direction::XBackward => X_NEG_AXIS,
@@ -47,6 +52,11 @@ impl Direction {
             Direction::ZForward => Z_POS_AXIS,
             Direction::ZBackward => Z_NEG_AXIS,
         }
+    }
+}
+impl From<Direction> for usize {
+    fn from(item: Direction) -> Self {
+        item as Self
     }
 }
 

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -1,4 +1,4 @@
-use std::{fmt, marker::PhantomData, ops::Range};
+use std::{fmt, fmt::Debug, marker::PhantomData, ops::Range};
 
 use crate::{
     coordinate_system::{Cartesian2D, Cartesian3D, CartesianCoordinates, CoordinateSystem},
@@ -17,7 +17,7 @@ pub type GridIndex = usize;
 /// Generic trait to represent a grid
 pub trait Grid<C: CoordinateSystem>: Clone {
     /// Position type used in this grid layout. Can be [GridIndex] if the grid elements have no position.
-    type Position;
+    type Position: Debug;
 
     /// Returns the [CoordinateSystem] used by this grid
     fn coord_system(&self) -> &C;

--- a/src/grid.rs
+++ b/src/grid.rs
@@ -43,9 +43,6 @@ pub trait Grid<C: CoordinateSystem>: Clone {
     fn pos_from_index(&self, index: GridIndex) -> Self::Position;
 }
 
-/// Generic trait to represent a grid with positions
-pub trait PositionalGrid<C: CoordinateSystem>: Grid<C> {}
-
 /// Definition of a grid
 #[derive(Clone)]
 #[cfg_attr(feature = "bevy", derive(Component, Default))]


### PR DESCRIPTION
- Keep GridIndex as is
- GridData still generic with an addition Grid parameter
- GridDefinition defines 'Grid's only if IsCartesian
- CoordinateSystem has associated types Direction, GridDelta, GridPosition with cartesian implementations
- DirectionTrait for Direction

Resolves Henauxg/ghx_proc_gen#1 which should really be opened here.

I'm starting this pull request to generate a discussion. GridDefinition, Direction, GridDelta and GridPosition may be moved under a Cartesian module.